### PR TITLE
This should hopefully fix wiping planets' conditions

### DIFF
--- a/src/data/scripts/campaign/colonies/VayraColonialManager.java
+++ b/src/data/scripts/campaign/colonies/VayraColonialManager.java
@@ -705,7 +705,9 @@ public class VayraColonialManager implements EveryFrameScript {
             float dist = Misc.getDistanceLY(sourceLoc, destLoc);
 
             for (PlanetAPI planet : system.getPlanets()) {
-                Misc.initConditionMarket(planet);
+                if (planet.getMarket() == null) {
+                    Misc.initConditionMarket(planet);
+                }
                 if (planet.isStar()) {
                     continue;
                 }


### PR DESCRIPTION
Well, the code iterated through all planets, and just reinitialized their market conditions without checking whether they were uninitialized first. That probably lead to the whole "wiping planets" effect that was being observed.

Lets see if this fixes it.