### PR TITLE
Add two mining ships/weapon CSV files suggested by PNG1

### DIFF
--- a/src/data/config/exerelin/mining_ships.csv
+++ b/src/data/config/exerelin/mining_ships.csv
@@ -1,0 +1,12 @@
+id,strength
+vayra_mining_hound,4
+vayra_heavy_drone_tender,18
+vayra_hammer_carrier,2
+vayra_mining_platform,2
+vayra_lr_mining_drone,0.5
+vayra_prospector,12
+vayra_spade,2
+vayra_groundhog,6
+vayra_pathfinder,75
+vayra_bear,200
+vayra_pioneer,35

--- a/src/data/config/exerelin/mining_weapons.csv
+++ b/src/data/config/exerelin/mining_weapons.csv
@@ -1,0 +1,12 @@
+id,strength
+vayra_light_cutter,2
+vayra_heavy_cutter,10
+vayra_hammer_pod,10
+vayra_degraded_particle_beam,5
+vayra_particle_beam,12
+vayra_biorifle,18
+vayra_lr_mining_laser,2
+vayra_mining_lance,2
+vayra_prospector_drill,15
+vayra_bear_claw,30
+vayra_not_guardian,10


### PR DESCRIPTION
As mentioned on discord, turns out this feature is available in some other Vayra Ships version but not the one contained in the VayraMerged mod.

Quoting:
> Hi. Not sure it's really a priority at current or anything, but I noticed when I was playing earlier today that the various nex mining values for Vayra ships and weapons didn't make it into the combined modpack
pulled these from the most recent version of the vayra ship pack I could find with a trivial amount of searching

So, why not. Screenshots apparently prove that it works so put them in.

Apparently, the Bear doesn't show up in the list without these files. So since i'm using it too - put it in.

# SCREENSHOTS:

screenshot:
![image](https://github.com/user-attachments/assets/40151025-f926-46b8-876e-c45c13ee4f81)
