### PR TITLE
Fix some crash from discord regarding null skills

### DIFF
--- a/src/data/scripts/campaign/intel/VayraPersonBountyIntel.java
+++ b/src/data/scripts/campaign/intel/VayraPersonBountyIntel.java
@@ -675,7 +675,6 @@ public final class VayraPersonBountyIntel extends BaseIntelPlugin implements Eve
             skillDesc = "having a high number of skilled subordinates";
         } else if (person.getStats().getSkillLevel(Skills.ELECTRONIC_WARFARE) > 0) {
             skillDesc = "being proficient in electronic warfare";
-//        } else if (person.getStats().getSkillLevel(Skills.FIGHTER_DOCTRINE) > 0) {
         } else if (person.getStats().getSkillLevel(Skills.CARRIER_GROUP) > 0) {
             skillDesc = "a noteworthy level of skill in running carrier operations";
         } else if (person.getStats().getSkillLevel(Skills.COORDINATED_MANEUVERS) > 0) {

--- a/src/data/scripts/campaign/intel/VayraUniqueBountyIntel.java
+++ b/src/data/scripts/campaign/intel/VayraUniqueBountyIntel.java
@@ -318,7 +318,6 @@ public class VayraUniqueBountyIntel extends BaseIntelPlugin implements EveryFram
             skillDesc = "having a high number of skilled subordinates";
         } else if (person.getStats().getSkillLevel(Skills.ELECTRONIC_WARFARE) > 0) {
             skillDesc = "being proficient in electronic warfare";
-//        } else if (person.getStats().getSkillLevel(Skills.FIGHTER_DOCTRINE) > 0) {
         } else if (person.getStats().getSkillLevel(Skills.CARRIER_GROUP) > 0) {
             skillDesc = "a noteworthy level of skill in running carrier operations";
         } else if (person.getStats().getSkillLevel(Skills.COORDINATED_MANEUVERS) > 0) {

--- a/src/data/world/factions/almighty_dollar.faction
+++ b/src/data/world/factions/almighty_dollar.faction
@@ -163,7 +163,7 @@
 		"commanderSkillsShuffleProbability":0,
 		"commanderSkills":[
 			"electronic_warfare",
-			"fighter_doctrine",
+			"carrier_group",
 			"officer_management",
 			"coordinated_maneuvers",
 		],

--- a/src/data/world/factions/ashen_keepers.faction
+++ b/src/data/world/factions/ashen_keepers.faction
@@ -149,7 +149,7 @@
 
 		"commanderSkillsShuffleProbability":0,
 		"commanderSkills":[
-			"fighter_doctrine",
+			"carrier_group",
 			"officer_management",
 			"coordinated_maneuvers",
 			"electronic_warfare",

--- a/src/data/world/factions/kadur_remnant.faction
+++ b/src/data/world/factions/kadur_remnant.faction
@@ -121,7 +121,7 @@
 		"commanderSkills":[
 			"officer_management",
 			"coordinated_maneuvers",
-			"fighter_doctrine",
+			"carrier_group",
 			"electronic_warfare",
 		],
 	},

--- a/src/data/world/factions/kadur_theocracy.faction
+++ b/src/data/world/factions/kadur_theocracy.faction
@@ -114,7 +114,7 @@
 		"commanderSkills":[
 			"officer_management",
 			"coordinated_maneuvers",
-			"fighter_doctrine",
+			"carrier_group",
 			"electronic_warfare",
 		],
 	},

--- a/src/data/world/factions/qamar_insurgency.faction
+++ b/src/data/world/factions/qamar_insurgency.faction
@@ -143,7 +143,7 @@
 		"commanderSkills":[
 			"officer_management",
 			"coordinated_maneuvers",
-			"fighter_doctrine",
+			"carrier_group",
 			"electronic_warfare",
 		],
 	},

--- a/src/data/world/factions/science_fuckers.faction
+++ b/src/data/world/factions/science_fuckers.faction
@@ -185,7 +185,7 @@
 		"commanderSkillsShuffleProbability":0,
 		"commanderSkills":[
 			"electronic_warfare",
-			"fighter_doctrine",
+			"carrier_group",
 			"officer_management",
 			"coordinated_maneuvers",
 		],

--- a/src/data/world/factions/warhawk_republic.faction
+++ b/src/data/world/factions/warhawk_republic.faction
@@ -197,7 +197,7 @@
 		"commanderSkills":[
 			"officer_management",
 			"coordinated_maneuvers",
-			"fighter_doctrine",
+			"carrier_group",
 			"electronic_warfare",
 		],
 	},


### PR DESCRIPTION
Turns out, the VayraPersonBountyIntel was still spawning fleets with "null" skills and assigning them levels.
While it may have not been a code problem, it was still a data problem, as many factions used the no-longer-existant skill of `"fighter_doctrine"` which was replaced with `"carrier_group"` in the code.

After it became clear that the FleetFactoryV3 was adding levels to `null` skills. And that using no-longer-existant skills in faction files is most likely the culprit, it's time to fix the factions.

So, this PR replaces all occurances of "fighter_doctrine" with "carrier_group" and hoping that that's the correct internal name of the skill.

Stacktrace in question:
```
java.lang.NullPointerException: Cannot invoke "com.fs.starfarer.loading.SkillSpec.isAptitudeEffect()" because the return value of "com.fs.starfarer.campaign.CharacterStats$SkillLevel.getSkill()" is null
    at com.fs.starfarer.campaign.CharacterStats.refreshCharacterStatsEffects(Unknown Source) ~[port_obf.jar:?]
    at com.fs.starfarer.campaign.CharacterStats.refreshCharacterStatsEffects(Unknown Source) ~[port_obf.jar:?]
    at com.fs.starfarer.api.impl.campaign.fleets.FleetFactoryV3.addCommanderSkills(FleetFactoryV3.java:1192) ~[starfarer.api.jar:?]
    at com.fs.starfarer.api.impl.campaign.fleets.FleetFactoryV3.addCommanderSkills(FleetFactoryV3.java:1904) ~[starfarer.api.jar:?]
    at data.scripts.campaign.intel.VayraPersonBountyIntel.spawnFleet(VayraPersonBountyIntel.java:1071) ~[?:?]
    at data.scripts.campaign.intel.VayraPersonBountyIntel.<init>(VayraPersonBountyIntel.java:205) ~[?:?]
    at data.scripts.campaign.intel.VayraPersonBountyManager.createEvent(VayraPersonBountyManager.java:326) ~[?:?]
    at data.scripts.campaign.intel.VayraPersonBountyManager.advance(VayraPersonBountyManager.java:300) ~[?:?]
    at data.scripts.VayraMergedModPlugin.onNewGameAfterTimePass(VayraMergedModPlugin.java:343) ~[?:?]
    at com.fs.starfarer.campaign.save.CampaignGameManager.o00000(Unknown Source) ~[port_obf.jar:?]
    at com.fs.starfarer.title.TitleScreenState.dialogDismissed(Unknown Source) ~[port_obf.jar:?]
    at com.fs.starfarer.ui.O.dismiss(Unknown Source) ~[port_obf.jar:?]
    at com.fs.starfarer.ui.impl.for.dismiss(Unknown Source) ~[port_obf.jar:?]
    at com.fs.starfarer.campaign.save.if.actionPerformed(Unknown Source) ~[port_obf.jar:?]
    at com.fs.starfarer.ui.o0O0.buttonPressed(Unknown Source) ~[port_obf.jar:?]
```

I don't know how to test this since I ran into this issue zero times so far. And after merging this in, lets see if others will too.