### PR TITLE
Alternative fix for issue #20

### DIFF
--- a/src/data/scripts/campaign/intel/VayraPersonBountyManager.java
+++ b/src/data/scripts/campaign/intel/VayraPersonBountyManager.java
@@ -73,7 +73,8 @@ public class VayraPersonBountyManager extends BaseEventManager {
 
     private void checkForFuckedUpParticipants() {
         checkedForFuckedUpParticipants = true;
-        for (Iterator<String> iter = getSharedData().getParticipatingFactions().iterator(); iter.hasNext(); ) {
+        List<String> participatingFactionsCopy = new ArrayList<String>(getSharedData().getParticipatingFactions());
+        for (Iterator<String> iter = participatingFactionsCopy.iterator(); iter.hasNext(); ) {
             String factionId = iter.next();
             if (Global.getSector().getFaction(factionId) == null) {
                 Global.getSector().getCampaignUI().addMessage(factionId + " is an invalid bounty participant, please yell at its mod author", Color.red);


### PR DESCRIPTION
As the title says - this is an alternative fix for issue #20 and all recreated instances of the ConcurrentModificationException in VayraPersonBountyManager.

Even with the iterator, if we're still getting this issue, that means the list itself is being poured-into from who knows how many places.

So lets not work on the original list, and instead work on a local copy.