### PR TITLE
Add new template for reporting issues in VayraMerged

### DIFF
--- a/.github/ISSUE_TEMPLATE/mod_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/mod_issue_template.md
@@ -1,0 +1,49 @@
+---
+name: Mod Issue Report
+about: Report an issue related to a mod
+title: "[Issue] <Descriptive title>"
+labels: bug
+assignees: ''
+---
+
+### Mod Name:
+<!-- Please provide the name of the mod. -->
+
+???
+
+### Mod Version:
+<!-- Please provide the version of the mod. -->
+
+???
+
+### Type of Issue:
+<!-- Please select the type of issue. -->
+- [ ] Defect
+- [ ] Crash
+- [ ] Something else
+
+### What were you doing when it happened?
+<!-- Describe the actions you were performing when the issue occurred. -->
+
+???
+
+### What did you expect to happen?
+<!-- Describe what you expected to happen. -->
+
+???
+
+### What actually happened?
+<!-- Describe what actually happened. -->
+
+???
+
+### Steps to Reproduce:
+<!-- Please list the steps to reproduce the issue. -->
+
+1. 
+2. 
+3. 
+
+### Screenshots/Logs:
+<!-- If applicable, add screenshots to help explain your problem. You can also paste any relevant logs here. -->
+


### PR DESCRIPTION
The point of this PR is to improve and streamline the issue reporting to make people at least include the version number.

This shouldn't be vayra-specific, but rather for the whole repo - however vayramerged will be the test lab rat.