### PR TITLE
Separate the 'issue' from 'crash' templates instead of relying on people

### DIFF
--- a/.github/ISSUE_TEMPLATE/mod_crash_template.md
+++ b/.github/ISSUE_TEMPLATE/mod_crash_template.md
@@ -1,8 +1,8 @@
 ---
-name: Mod Issue Report
-about: Report an issue related to a mod
-title: "[Issue] <Descriptive title>"
-labels: bug
+name: Mod Crash Report
+about: Report a crash related to a mod
+title: "[Crash] <Descriptive title>"
+labels: crash
 assignees: ''
 ---
 
@@ -16,13 +16,8 @@ assignees: ''
 
 ???
 
-### What did you expect to happen?
-<!-- Describe what you expected to happen. -->
-
-???
-
-### What actually happened?
-<!-- Describe what actually happened. -->
+### What were you doing when it happened?
+<!-- Describe the actions you were performing when the crash occurred. -->
 
 ???
 

--- a/.github/ISSUE_TEMPLATE/mod_crash_template.md
+++ b/.github/ISSUE_TEMPLATE/mod_crash_template.md
@@ -31,3 +31,7 @@ assignees: ''
 ### Screenshots/Logs:
 <!-- If applicable, add screenshots to help explain your problem. You can also paste any relevant logs here. -->
 
+
+
+### Additional info:
+<!-- Any additional information you'd like to add to further clarify/explain the issue -->

--- a/.github/ISSUE_TEMPLATE/mod_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/mod_issue_template.md
@@ -36,3 +36,7 @@ assignees: ''
 ### Screenshots/Logs:
 <!-- If applicable, add screenshots to help explain your problem. You can also paste any relevant logs here. -->
 
+
+
+### Additional info:
+<!-- Any additional information you'd like to add to further clarify/explain the issue -->


### PR DESCRIPTION
People won't even fill these out half of the time, it was expecting too much.
But, separate 'issue' reports from 'crash' reports.