### PR TITLE
Fix IndexOutOfBoundsException occuring in VayraJoachimEffect

### DIFF
--- a/src/data/scripts/hullmods/VayraDamagedOptics.java
+++ b/src/data/scripts/hullmods/VayraDamagedOptics.java
@@ -6,6 +6,8 @@ import com.fs.starfarer.api.combat.ShipAPI.HullSize;
 import com.fs.starfarer.api.impl.campaign.ids.Stats;
 import com.fs.starfarer.api.impl.hullmods.CompromisedStructure;
 
+import static data.scripts.util.MiscUtils.getMaximumWeaponSpecAngleOffsetsSize;
+
 public class VayraDamagedOptics extends BaseHullMod {
 
     public static final float BEAM_RANGE_MULT = 0.75f;
@@ -34,14 +36,17 @@ public class VayraDamagedOptics extends BaseHullMod {
         for (WeaponAPI w : ship.getAllWeapons()) {
             if (w.isBeam() && w.isFiring()) {
                 float[] moveArray = generateMoveArray(ship, w);
-                for (int i = 0; i < w.getSpec().getTurretAngleOffsets().size(); i++) {
-                    w.getSpec().getTurretAngleOffsets().set(i, moveArray[i]);
-                }
-                for (int i = 0; i < w.getSpec().getHardpointAngleOffsets().size(); i++) {
-                    w.getSpec().getHardpointAngleOffsets().set(i, moveArray[i]);
-                }
-                for (int i = 0; i < w.getSpec().getHiddenAngleOffsets().size(); i++) {
-                    w.getSpec().getHiddenAngleOffsets().set(i, moveArray[i]);
+                int maxOffsetSize = getMaximumWeaponSpecAngleOffsetsSize(w);
+                for (int i = 0; i < maxOffsetSize; i++) {
+                    if (i < w.getSpec().getTurretAngleOffsets().size()) {
+                        w.getSpec().getTurretAngleOffsets().set(i, moveArray[i]);
+                    }
+                    if (i < w.getSpec().getHardpointAngleOffsets().size()) {
+                        w.getSpec().getHardpointAngleOffsets().set(i, moveArray[i]);
+                    }
+                    if (i < w.getSpec().getHiddenAngleOffsets().size()) {
+                        w.getSpec().getHiddenAngleOffsets().set(i, moveArray[i]);
+                    }
                 }
             }
         }
@@ -50,10 +55,7 @@ public class VayraDamagedOptics extends BaseHullMod {
     private float[] generateMoveArray(ShipAPI ship, WeaponAPI weapon) {
         float beamWaver = getBeamWaverValue(ship);
         // First, figure out how many items we have
-        int size = 0;
-        size = Math.max(size, weapon.getSpec().getTurretAngleOffsets().size());
-        size = Math.max(size, weapon.getSpec().getHardpointAngleOffsets().size());
-        size = Math.max(size, weapon.getSpec().getHiddenAngleOffsets().size());
+        int size = getMaximumWeaponSpecAngleOffsetsSize(weapon);
 
         // now that we know how large the random array should be, lets create it
         float[] retVal = new float[size];

--- a/src/data/scripts/util/MiscUtils.java
+++ b/src/data/scripts/util/MiscUtils.java
@@ -1,0 +1,27 @@
+package data.scripts.util;
+
+import com.fs.starfarer.api.combat.WeaponAPI;
+import com.fs.starfarer.api.loading.WeaponSpecAPI;
+
+/**
+ * Bunch of small copypastable methods belonging everywhere but nowhere in specific
+ */
+public class MiscUtils {
+    /**
+     * Returns the maximum size of {@link WeaponAPI} angle offsets by looking at it's:
+     * {@link WeaponSpecAPI#getTurretAngleOffsets()},
+     * {@link WeaponSpecAPI#getHardpointAngleOffsets()}
+     * {@link WeaponSpecAPI#getHiddenAngleOffsets()}
+     *
+     * @param weapon the weapon to lookup
+     * @return the max size of these three things
+     */
+    public static int getMaximumWeaponSpecAngleOffsetsSize(WeaponAPI weapon) {
+        int size = 0;
+        size = Math.max(size, weapon.getSpec().getTurretAngleOffsets().size());
+        size = Math.max(size, weapon.getSpec().getHardpointAngleOffsets().size());
+        size = Math.max(size, weapon.getSpec().getHiddenAngleOffsets().size());
+
+        return size;
+    }
+}

--- a/src/data/scripts/weapons/VayraJoachimEffect.java
+++ b/src/data/scripts/weapons/VayraJoachimEffect.java
@@ -5,6 +5,7 @@ import com.fs.starfarer.api.Global;
 import com.fs.starfarer.api.combat.CombatEngineAPI;
 import com.fs.starfarer.api.combat.EveryFrameWeaponEffectPlugin;
 import com.fs.starfarer.api.combat.WeaponAPI;
+import com.fs.starfarer.api.loading.WeaponSpecAPI;
 import org.apache.log4j.Logger;
 import org.lazywizard.lazylib.FastTrig;
 import org.lazywizard.lazylib.MathUtils;
@@ -12,7 +13,6 @@ import org.lazywizard.lazylib.VectorUtils;
 import org.lwjgl.util.vector.Vector2f;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,18 +33,68 @@ public class VayraJoachimEffect implements EveryFrameWeaponEffectPlugin {
     private float fireTime = 0;
     private boolean restart = false;
 
+    /**
+     * Returns the <i>index</i> from <i>list</i> if it's within bounds, for OutOfBound indices returns the last element
+     *
+     * @param list the list to get an element from
+     * @param index the index of the element to get
+     * @return the list[index] element or list[size-1] element if index >= list.size()
+     */
+    private float safeGetFromArrayList(List<Float> list, int index) {
+        float retVal = 0;
+        if (index < list.size()) {
+            retVal = list.get(index);
+        } else {
+            retVal = list.get(list.size() - 1);
+        }
+
+        return retVal;
+    }
+
+    /**
+     * Generates the move array for a given {@link WeaponAPI} by looking at it's:
+     * {@link WeaponSpecAPI#getTurretAngleOffsets()},
+     * {@link WeaponSpecAPI#getHardpointAngleOffsets()}
+     * {@link WeaponSpecAPI#getHiddenAngleOffsets()}
+     * <br>
+     * taking the max of all three sizes and generating a move array out of that by the specified formula.
+     *
+     * @param weapon the weapon for which to generate the move array
+     * @return the move array
+     */
+    private float[] generateMoveArray(WeaponAPI weapon) {
+        // First, figure out how many items we have
+        int size = 0;
+        size = Math.max(size, weapon.getSpec().getTurretAngleOffsets().size());
+        size = Math.max(size, weapon.getSpec().getHardpointAngleOffsets().size());
+        size = Math.max(size, weapon.getSpec().getHiddenAngleOffsets().size());
+
+        // now that we know how large the random array should be, lets create it
+        float[] retVal = new float[size];
+        for (int i = 0; i < size; i++) {
+            retVal[i] =  (2 * i - 1) * (DISTANCE_MAX / FIRE_TIME) * (float) FastTrig.cos(fireTime);
+        }
+
+        return retVal;
+    }
+
     @Override
     public void advance(float amount, CombatEngineAPI engine, WeaponAPI weapon) {
-        //Don't run if we are paused, or our weapon is null
+        // Don't run if we are paused, or our weapon is null
         if (engine.isPaused() || weapon == null) {
             return;
         }
 
         if (restart) {
+            //TODO consider unifying these loops in just one, so that they all move in-sync rather than in-order
             for (int i = 0; i < weapon.getSpec().getTurretAngleOffsets().size(); i++) {
-                weapon.getSpec().getHardpointAngleOffsets().set(i, BASE_ANGLES.get(i));
-                weapon.getSpec().getTurretAngleOffsets().set(i, BASE_ANGLES.get(i));
-                weapon.getSpec().getHiddenAngleOffsets().set(i, BASE_ANGLES.get(i));
+                weapon.getSpec().getHardpointAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
+            }
+            for (int i = 0; i < weapon.getSpec().getHardpointAngleOffsets().size(); i++) {
+                weapon.getSpec().getHardpointAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
+            }
+            for (int i = 0; i < weapon.getSpec().getHiddenAngleOffsets().size(); i++) {
+                weapon.getSpec().getHiddenAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
             }
         }
 
@@ -53,11 +103,16 @@ public class VayraJoachimEffect implements EveryFrameWeaponEffectPlugin {
             fireTime += amount;
 
             // sweep the beam
+            float[] moveArray = generateMoveArray(weapon);
+            //TODO consider unifying these loops in just one, so that they all move in-sync rather than in-order
             for (int i = 0; i < weapon.getSpec().getTurretAngleOffsets().size(); i++) {
-                float move = (2 * i - 1) * (DISTANCE_MAX / FIRE_TIME) * (float) FastTrig.cos(fireTime);
-                weapon.getSpec().getHardpointAngleOffsets().set(i, move);
-                weapon.getSpec().getTurretAngleOffsets().set(i, move);
-                weapon.getSpec().getHiddenAngleOffsets().set(i, move);
+                weapon.getSpec().getTurretAngleOffsets().set(i, moveArray[i]);
+            }
+            for (int i = 0; i < weapon.getSpec().getHardpointAngleOffsets().size(); i++) {
+                weapon.getSpec().getHardpointAngleOffsets().set(i, moveArray[i]);
+            }
+            for (int i = 0; i < weapon.getSpec().getHiddenAngleOffsets().size(); i++) {
+                weapon.getSpec().getHiddenAngleOffsets().set(i, moveArray[i]);
             }
 
             // spawn particles

--- a/src/data/scripts/weapons/VayraJoachimEffect.java
+++ b/src/data/scripts/weapons/VayraJoachimEffect.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static data.scripts.util.MiscUtils.getMaximumWeaponSpecAngleOffsetsSize;
+
 public class VayraJoachimEffect implements EveryFrameWeaponEffectPlugin {
 
     public static Logger log = Global.getLogger(VayraJoachimEffect.class);
@@ -64,10 +66,7 @@ public class VayraJoachimEffect implements EveryFrameWeaponEffectPlugin {
      */
     private float[] generateMoveArray(WeaponAPI weapon) {
         // First, figure out how many items we have
-        int size = 0;
-        size = Math.max(size, weapon.getSpec().getTurretAngleOffsets().size());
-        size = Math.max(size, weapon.getSpec().getHardpointAngleOffsets().size());
-        size = Math.max(size, weapon.getSpec().getHiddenAngleOffsets().size());
+        int size = getMaximumWeaponSpecAngleOffsetsSize(weapon);
 
         // now that we know how large the random array should be, lets create it
         float[] retVal = new float[size];
@@ -78,6 +77,8 @@ public class VayraJoachimEffect implements EveryFrameWeaponEffectPlugin {
         return retVal;
     }
 
+
+
     @Override
     public void advance(float amount, CombatEngineAPI engine, WeaponAPI weapon) {
         // Don't run if we are paused, or our weapon is null
@@ -86,15 +87,17 @@ public class VayraJoachimEffect implements EveryFrameWeaponEffectPlugin {
         }
 
         if (restart) {
-            //TODO consider unifying these loops in just one, so that they all move in-sync rather than in-order
-            for (int i = 0; i < weapon.getSpec().getTurretAngleOffsets().size(); i++) {
-                weapon.getSpec().getHardpointAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
-            }
-            for (int i = 0; i < weapon.getSpec().getHardpointAngleOffsets().size(); i++) {
-                weapon.getSpec().getHardpointAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
-            }
-            for (int i = 0; i < weapon.getSpec().getHiddenAngleOffsets().size(); i++) {
-                weapon.getSpec().getHiddenAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
+            int maxOffsetSize = getMaximumWeaponSpecAngleOffsetsSize(weapon);
+            for (int i = 0; i < maxOffsetSize; i++) {
+                if (i < weapon.getSpec().getTurretAngleOffsets().size()) {
+                    weapon.getSpec().getTurretAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
+                }
+                if (i < weapon.getSpec().getHardpointAngleOffsets().size()) {
+                    weapon.getSpec().getHardpointAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
+                }
+                if (i < weapon.getSpec().getHiddenAngleOffsets().size()) {
+                    weapon.getSpec().getHiddenAngleOffsets().set(i, safeGetFromArrayList(BASE_ANGLES, i));
+                }
             }
         }
 
@@ -104,15 +107,17 @@ public class VayraJoachimEffect implements EveryFrameWeaponEffectPlugin {
 
             // sweep the beam
             float[] moveArray = generateMoveArray(weapon);
-            //TODO consider unifying these loops in just one, so that they all move in-sync rather than in-order
-            for (int i = 0; i < weapon.getSpec().getTurretAngleOffsets().size(); i++) {
-                weapon.getSpec().getTurretAngleOffsets().set(i, moveArray[i]);
-            }
-            for (int i = 0; i < weapon.getSpec().getHardpointAngleOffsets().size(); i++) {
-                weapon.getSpec().getHardpointAngleOffsets().set(i, moveArray[i]);
-            }
-            for (int i = 0; i < weapon.getSpec().getHiddenAngleOffsets().size(); i++) {
-                weapon.getSpec().getHiddenAngleOffsets().set(i, moveArray[i]);
+            int maxOffsetSize = getMaximumWeaponSpecAngleOffsetsSize(weapon);
+            for (int i = 0; i < maxOffsetSize; i++) {
+                if (i < weapon.getSpec().getTurretAngleOffsets().size()) {
+                    weapon.getSpec().getTurretAngleOffsets().set(i, moveArray[i]);
+                }
+                if (i < weapon.getSpec().getHardpointAngleOffsets().size()) {
+                    weapon.getSpec().getHardpointAngleOffsets().set(i, moveArray[i]);
+                }
+                if (i < weapon.getSpec().getHiddenAngleOffsets().size()) {
+                    weapon.getSpec().getHiddenAngleOffsets().set(i, moveArray[i]);
+                }
             }
 
             // spawn particles


### PR DESCRIPTION
This PR mainly focuses on fixing an identical problem that was present in `VayraDamagedOptics` hullmod, which is using a size of one weapon angle offset for all three different weapon angle offsets... and also improves the old fix in VayraDamagedOptics to use the new in-sync rotation approach rather than the wrong in-order that was there until now.

Stacktrace for reference:
```
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100) ~[?:?]
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) ~[?:?]
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) ~[?:?]
        at java.base/java.util.Objects.checkIndex(Objects.java:365) ~[?:?]
        at java.base/java.util.ArrayList.get(ArrayList.java:428) ~[?:?]
        at data.scripts.weapons.VayraJoachimEffect.advance(VayraJoachimEffect.java:45) ~[?:?]
```